### PR TITLE
Add bicycle image upload functionality

### DIFF
--- a/bicycle-inventory.php
+++ b/bicycle-inventory.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Bicycle Inventory Manager
  * Description: A plugin to manage bicycle inventory
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Your Name
  * License: GPL v2 or later
  */
@@ -10,6 +10,15 @@
 if (!defined('ABSPATH')) {
     exit;
 }
+
+// Enqueue required scripts and styles
+function bi_enqueue_admin_scripts() {
+    if (get_post_type() === 'bicycle') {
+        wp_enqueue_media();
+        wp_enqueue_script('bi-admin-script', plugins_url('js/admin.js', __FILE__), array('jquery'), '1.0.0', true);
+    }
+}
+add_action('admin_enqueue_scripts', 'bi_enqueue_admin_scripts');
 
 // Create custom post type for bicycles
 function bi_register_bicycle_post_type() {
@@ -25,7 +34,7 @@ function bi_register_bicycle_post_type() {
         'public' => true,
         'has_archive' => true,
         'menu_icon' => 'dashicons-bike',
-        'supports' => ['title', 'editor', 'custom-fields']
+        'supports' => ['title', 'editor', 'custom-fields', 'thumbnail']
     ]);
 }
 add_action('init', 'bi_register_bicycle_post_type');
@@ -36,6 +45,15 @@ function bi_add_bicycle_meta_boxes() {
         'bicycle_details',
         'Bicycle Details',
         'bi_render_bicycle_details_meta_box',
+        'bicycle',
+        'normal',
+        'high'
+    );
+    
+    add_meta_box(
+        'bicycle_gallery',
+        'Bicycle Gallery',
+        'bi_render_bicycle_gallery_meta_box',
         'bicycle',
         'normal',
         'high'
@@ -71,29 +89,93 @@ function bi_render_bicycle_details_meta_box($post) {
     <?php
 }
 
+// Render gallery meta box
+function bi_render_bicycle_gallery_meta_box($post) {
+    wp_nonce_field('bicycle_gallery_nonce', 'bicycle_gallery_nonce');
+    $image_ids = get_post_meta($post->ID, '_bicycle_gallery', true);
+    $image_ids = $image_ids ? explode(',', $image_ids) : array();
+    ?>
+    <div id="bicycle-gallery-container">
+        <div id="bicycle-gallery-preview">
+            <?php
+            foreach ($image_ids as $image_id) {
+                $image_url = wp_get_attachment_image_url($image_id, 'thumbnail');
+                if ($image_url) {
+                    echo '<div class="gallery-image" data-id="' . esc_attr($image_id) . '">';
+                    echo '<img src="' . esc_url($image_url) . '" />';
+                    echo '<button class="remove-image">×</button>';
+                    echo '</div>';
+                }
+            }
+            ?>
+        </div>
+        <input type="hidden" name="bicycle_gallery" id="bicycle_gallery" value="<?php echo esc_attr(implode(',', $image_ids)); ?>">
+        <button type="button" id="add_bicycle_images" class="button">Add Images</button>
+    </div>
+    <style>
+        #bicycle-gallery-preview {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-bottom: 10px;
+        }
+        .gallery-image {
+            position: relative;
+            width: 150px;
+            height: 150px;
+        }
+        .gallery-image img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+        .remove-image {
+            position: absolute;
+            top: 5px;
+            right: 5px;
+            background: rgba(255, 0, 0, 0.7);
+            color: white;
+            border: none;
+            border-radius: 50%;
+            width: 20px;
+            height: 20px;
+            cursor: pointer;
+        }
+    </style>
+    <?php
+}
+
 // Save meta box data
 function bi_save_bicycle_meta_box_data($post_id) {
-    if (!isset($_POST['bicycle_details_nonce']) ||
-        !wp_verify_nonce($_POST['bicycle_details_nonce'], 'bicycle_details_nonce')) {
-        return;
+    // Save regular details
+    if (isset($_POST['bicycle_details_nonce']) &&
+        wp_verify_nonce($_POST['bicycle_details_nonce'], 'bicycle_details_nonce')) {
+        
+        if (!current_user_can('edit_post', $post_id) || defined('DOING_AUTOSAVE')) {
+            return;
+        }
+
+        $fields = ['bicycle_brand', 'bicycle_model', 'bicycle_year', 'bicycle_serial'];
+        foreach ($fields as $field) {
+            if (isset($_POST[$field])) {
+                update_post_meta(
+                    $post_id,
+                    '_' . $field,
+                    sanitize_text_field($_POST[$field])
+                );
+            }
+        }
     }
 
-    if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
-        return;
-    }
-
-    if (!current_user_can('edit_post', $post_id)) {
-        return;
-    }
-
-    $fields = ['bicycle_brand', 'bicycle_model', 'bicycle_year', 'bicycle_serial'];
-    
-    foreach ($fields as $field) {
-        if (isset($_POST[$field])) {
+    // Save gallery
+    if (isset($_POST['bicycle_gallery_nonce']) &&
+        wp_verify_nonce($_POST['bicycle_gallery_nonce'], 'bicycle_gallery_nonce')) {
+        
+        if (isset($_POST['bicycle_gallery'])) {
             update_post_meta(
                 $post_id,
-                '_' . $field,
-                sanitize_text_field($_POST[$field])
+                '_bicycle_gallery',
+                sanitize_text_field($_POST['bicycle_gallery'])
             );
         }
     }

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,59 @@
+jQuery(document).ready(function($) {
+    var frame;
+    
+    $('#add_bicycle_images').on('click', function(e) {
+        e.preventDefault();
+        
+        if (frame) {
+            frame.open();
+            return;
+        }
+        
+        frame = wp.media({
+            title: 'Select Bicycle Images',
+            button: {
+                text: 'Add to gallery'
+            },
+            multiple: true
+        });
+        
+        frame.on('select', function() {
+            var attachments = frame.state().get('selection').map(function(attachment) {
+                attachment = attachment.toJSON();
+                return {
+                    id: attachment.id,
+                    url: attachment.sizes.thumbnail ? attachment.sizes.thumbnail.url : attachment.url
+                };
+            });
+            
+            var ids = $('#bicycle_gallery').val();
+            ids = ids ? ids.split(',') : [];
+            
+            attachments.forEach(function(attachment) {
+                if (!ids.includes(attachment.id.toString())) {
+                    ids.push(attachment.id);
+                    $('#bicycle-gallery-preview').append(
+                        '<div class="gallery-image" data-id="' + attachment.id + '">' +
+                        '<img src="' + attachment.url + '" />' +
+                        '<button class="remove-image">×</button>' +
+                        '</div>'
+                    );
+                }
+            });
+            
+            $('#bicycle_gallery').val(ids.join(','));
+        });
+        
+        frame.open();
+    });
+    
+    $('#bicycle-gallery-preview').on('click', '.remove-image', function(e) {
+        e.preventDefault();
+        var container = $(this).parent();
+        var id = container.data('id').toString();
+        var ids = $('#bicycle_gallery').val().split(',');
+        ids = ids.filter(function(val) { return val !== id; });
+        $('#bicycle_gallery').val(ids.join(','));
+        container.remove();
+    });
+});


### PR DESCRIPTION
This PR adds the ability for users to upload and manage multiple images for each bicycle in their inventory.

Changes include:
- Added a new gallery meta box for managing bicycle images
- Integrated WordPress media uploader
- Added JavaScript handling for image upload and removal
- Updated styles for gallery display
- Added proper nonce verification for security

The feature allows users to:
- Upload multiple images per bicycle
- Remove images from the gallery
- See thumbnail previews of uploaded images
- Maintain image associations even when editing